### PR TITLE
Handle variation in API response: offers can also be a hash

### DIFF
--- a/stw_potsdam/feed.py
+++ b/stw_potsdam/feed.py
@@ -40,13 +40,30 @@ def _prices(offer):
 
 
 def _process_day(builder, day):
-    for offer in day['angebote']:
+    for offer in _offers(day):
         builder.addMeal(date=day['data'],
                         category=offer['titel'],
                         name=offer['beschreibung'],
                         notes=_notes(offer),
                         prices=_prices(offer),
                         roles=None)
+
+
+def _offers(day):
+    offers = day['angebote']
+    if isinstance(offers, list):
+        return offers
+
+    if isinstance(offers, dict):
+        # allows for the following structure:
+        # {'-1': <garbage>, '0': first_offer, ...}
+        # This case is degenerate and occurs only on semi-regular basis
+        # as of 2020-10-20. The assumption that offers at logical index -1
+        # are garbage can be challenged, it is simply a result of observing
+        # the API responses over several months.
+        return [offer for index, offer in offers.items() if int(index) >= 0]
+
+    raise AssertionError(f'cannot handle offers of type {type(offers)}')
 
 
 def render_menu(menu):

--- a/tests/resources/offers-dict-output.xml
+++ b/tests/resources/offers-dict-output.xml
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openmensa version="2.1" xmlns="http://openmensa.org/open-mensa-v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://openmensa.org/open-mensa-v2 http://openmensa.org/open-mensa-v2.xsd">
+  <canteen>
+    <day date="2020-10-09">
+      <category name="Angebot 1">
+        <meal>
+          <name>Hausgemachte Kartoffelpuffer mit Apfelmus</name>
+          <note>Vegetarisch</note>
+          <price role="employee">3.10</price>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 2">
+        <meal>
+          <name>Chili con Carne mit Langkornreis
+oder Pommes frites, dazu bunter Salat</name>
+          <note>Rind</note>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+      </category>
+      <category name="Angebot 3">
+        <meal>
+          <name>Seelachsfilet in Sesampanade 
+mit pikanter Salsa, dazu gebratene Mini-Kartoffeln oder Langkornreis und Gurkensalat</name>
+          <note>Fisch</note>
+          <note>Knoblauch</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Tagessuppe 1,00 €">
+        <meal>
+          <name>t</name>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 4">
+        <meal>
+          <name>Currysuppe mit Steckrüben, Bohnen und Paprika</name>
+          <note>Mensavital</note>
+          <note>Vegan</note>
+          <price role="employee">1.00</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Cafeteria Angebot">
+        <meal>
+          <name>Zupfkuchen 1,60 €
+Donuts 1,30 €
+Obstsalat 2,00 €
+Joghurt mit Früchte Müsli und Obst 2,00 € Cookie 1,30
+hausgemachte Waffeln 1,60 €
+Flaguline versch. belegt 3,00 €
+Ciabatta verschieden belegt 2,50 €</name>
+        </meal>
+      </category>
+    </day>
+    <day date="2020-10-10">
+      <category name="Angebot 4">
+        <meal>
+          <name>f</name>
+          <price role="employee">1.00</price>
+          <price role="other">1.00</price>
+          <price role="student">1.00</price>
+        </meal>
+      </category>
+    </day>
+    <day date="2020-10-12">
+      <category name="Angebot 1">
+        <meal>
+          <name>Gekochte Eier in Senfsauce, dazu Kartoffelpüree</name>
+          <note>Vegetarisch</note>
+          <price role="employee">3.10</price>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 2">
+        <meal>
+          <name>Vegetarische Kohlroulade mit Schmorkohlsauce und Salzkartoffeln</name>
+          <note>Regional</note>
+          <note>Vegetarisch</note>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+        <meal>
+          <name>Kohlroulade mit Schmorkohlsauce und Salzkartoffeln</name>
+          <note>Regional</note>
+          <note>Schwein</note>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+      </category>
+      <category name="Angebot 3">
+        <meal>
+          <name>Hähnchenbrust mit roter Currysauce, dazu Thai-Gemüse und Duftreis oder Bratnudeln</name>
+          <note>Geflügel</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 4">
+        <meal>
+          <name>Limetten-Spaghetti mit Erbsen, Pilzen und Cashewkernen</name>
+          <note>Mensavital</note>
+          <note>Vegan</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+    </day>
+    <day date="2020-10-13">
+      <category name="Angebot 1">
+        <meal>
+          <name>Brühnudeln mit Wurzelgemüse und Sojawürfeln, dazu Brot</name>
+          <note>Vegan</note>
+          <price role="employee">3.10</price>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 2">
+        <meal>
+          <name>Sojastreifen in Honig-Senf-Sauce 
+mit Mandel-Kartoffeln, dazu Salatmix
+und Mandarinen-Joghurt-Dressing</name>
+          <note>Vegetarisch</note>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+        <meal>
+          <name>Hähnchenbruststreifen in Honig-Senf-Sauce 
+mit Mandel-Kartoffeln, dazu Salatmix 
+und Mandarinen-Joghurt-Dressing</name>
+          <note>Geflügel</note>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+      </category>
+      <category name="Angebot 3">
+        <meal>
+          <name>Wildgulasch mit Rotkohl und Klöße oder Spätzle</name>
+          <note>Alkohol</note>
+          <note>Regional</note>
+          <note>Schwein</note>
+          <note>Wild</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 4">
+        <meal>
+          <name>Älpler Maggerone mit Appenzeller Käse überbacken, dazu Apfelmus und Tessiner Mischsalat</name>
+          <note>Vegetarisch</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+    </day>
+    <day date="2020-10-14">
+      <category name="Angebot 1">
+        <meal>
+          <name>Spaghetti mit Florentiner Sauce</name>
+          <note>Knoblauch</note>
+          <note>Vegetarisch</note>
+          <price role="employee">3.10</price>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 2">
+        <meal>
+          <name>Vegetarische Klopse mit Möhrengemüse und Salzkartoffeln oder Langkornreis</name>
+          <note>Regional</note>
+          <note>Vegetarisch</note>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+        <meal>
+          <name>Königsberger Klopse mit Möhrengemüse und Salzkartoffeln oder Langkornreis</name>
+          <note>Regional</note>
+          <note>Rind</note>
+          <note>Schwein</note>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+      </category>
+      <category name="Angebot 3">
+        <meal>
+          <name>Fangfrisches Fischfilet 
+mit Orangen-Pfeffersauce und Fenchel-Tomaten-Gemüse, 
+dazu Kartoffelgnocchi oder Bandnudeln</name>
+          <note>Alkohol</note>
+          <note>Fisch</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 4">
+        <meal>
+          <name>Vegane Frühlingsrolle auf asiatischem Gemüse mit Mango-Chutney und scharfem Kokosreis</name>
+          <note>Vegan</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+    </day>
+    <day date="2020-10-15">
+      <category name="Angebot 1">
+        <meal>
+          <name>Hefeklöße mit Waldbeeren oder Zimtpflaumen</name>
+          <note>Vegetarisch</note>
+          <price role="employee">3.10</price>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 2">
+        <meal>
+          <name>Hering nach Hausfrauen Art mit Salzkartoffeln und Salatbeilage</name>
+          <note>Fisch</note>
+          <note>Regional</note>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+      </category>
+      <category name="Angebot 3">
+        <meal>
+          <name>Sojasteak mit zerlassener Thymianbutter und Peperonata, dazu Kartoffelgnocchi oder Bratkartoffeln</name>
+          <note>Vegetarisch</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+        <meal>
+          <name>Schweinesteak mit zerlassener Thymianbutter und Peperonata, dazu Kartoffelgnocchi oder Bratkartoffeln</name>
+          <note>Schwein</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 4">
+        <meal>
+          <name>Gelbe Linsen mit Kokos-Curry 
+und Bananen-Soja-Shake</name>
+          <note>Knoblauch</note>
+          <note>Mensavital</note>
+          <note>Vegan</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+    </day>
+    <day date="2020-10-16">
+      <category name="Angebot 1">
+        <meal>
+          <name>Bunter Gemüseeintopf mit Kichererbsen, dazu Brot</name>
+          <note>Vegan</note>
+          <price role="employee">3.10</price>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+        <meal>
+          <name>Topfwurst mit buntem Sauerkraut und Salzkartoffeln</name>
+          <note>Regional</note>
+          <note>Schwein</note>
+          <price role="employee">3.10</price>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 2">
+        <meal>
+          <name>Schweinebraten mit Rosenkohl und Serviettenknödel oder Salzkartoffeln</name>
+          <note>Schwein</note>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+      </category>
+      <category name="Angebot 3">
+        <meal>
+          <name>Seelachs in Kräuter-Ei-Hülle auf dänischer Senfsauce mit Tricolore-Gemüse und Kartoffelgratin</name>
+          <note>Fisch</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 4">
+        <meal>
+          <name>Kartoffel-Kürbiskernrösti 
+mit Tomaten-Schnittlauchquark, dazu Blattsalatvariation</name>
+          <note>Mensavital</note>
+          <note>Vegetarisch</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+    </day>
+  </canteen>
+</openmensa>

--- a/tests/resources/offers-dict.json
+++ b/tests/resources/offers-dict.json
@@ -1,0 +1,4006 @@
+{
+  "globalLaufschrift": "Bitte Mindestabstand von 1,5 Metern einhalten ### Mund und Nasenschutz tragen ### Speisenverkauf nur f\u00fcr den sofortigen Verzehr",
+  "wochentage": [
+    {
+      "datum": {
+        "wochentag": "5",
+        "data": "09.10.2020",
+        "freitagsmodus": {
+          "fmwert": "2",
+          "konf": [
+            {
+              "index": "1",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "2",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "3",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "4",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "5",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "6",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "7",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "8",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            }
+          ]
+        },
+        "globaleetage": {
+          "icon_eg": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_eg.png",
+          "icon_og": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_og.png",
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_vegetarisch_v.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_vegetarisch_v.png"
+          ],
+          "vegan": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_vegan_w.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_vegan_w.png"
+          ],
+          "vital": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vital_m.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_vital_m.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_vital_m.png"
+          ],
+          "schwein": [],
+          "fisch": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_fisch_f.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_fisch_f.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_fisch_f.png"
+          ],
+          "rind": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_rind_r.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_rind_r.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_rind_r.png"
+          ],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_knoblauch_k.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_knoblauch_k.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_knoblauch_k.png"
+          ],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "Angebot 1",
+            "laufschrift": "",
+            "angebotshinweis": "Die Angebote 1 bis 4 inklusive einem Frischobst.",
+            "index": "1",
+            "matrix": "9a",
+            "beschreibung": "Hausgemachte Kartoffelpuffer mit Apfelmus",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "3, 9, C, Wei",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "9",
+                    "be": "mit S\u00fc\u00dfungsmittel",
+                    "lbz": "S\u00fc\u00dfstoffe, liefern kaum Nahrungsenergie und werden deshalb u.a. in energiereduzierten Lebensmitteln eingesetzt"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": "3.10",
+            "preis_g": "3.10",
+            "id": 0,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              }
+            ],
+            "screenid": "1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 2",
+            "laufschrift": "",
+            "angebotshinweis": "Die Angebote 1 bis 4 inklusive einem Frischobst.",
+            "index": "2",
+            "matrix": "9b",
+            "beschreibung": "Chili con Carne mit Langkornreis\noder Pommes frites, dazu bunter Salat",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "3, Wei",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 1,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_rind_r.png",
+                "name": "Rind",
+                "translatedfilter": "rind"
+              }
+            ],
+            "screenid": "2",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": "",
+            "angebotshinweis": "Die Angebote 1 bis 4 inklusive einem Frischobst.",
+            "index": "3",
+            "matrix": "9c",
+            "beschreibung": "Seelachsfilet in Sesampanade \nmit pikanter Salsa, dazu gebratene Mini-Kartoffeln oder Langkornreis und Gurkensalat",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": true,
+                "alkohol": false,
+                "knoblauch": true,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "KNO, 5, D, K, Wei, L",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "KNO",
+                    "be": "mit Knoblauch",
+                    "lbz": {
+                      "@attributes": {
+                        "info": "Lebensmitteltechnologische Bedeutung des Zusatzstoffes"
+                      }
+                    }
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "5",
+                    "be": "geschwefelt",
+                    "lbz": "Schwefel dient der Abt\u00f6tung von unerw\u00fcnschten Mikroorganismen"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "D",
+                    "be": "Fisch",
+                    "ie": "Paella, Bouillabaise, Worchester Sauce, asiatische W\u00fcrzpasten"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "K",
+                    "be": "Sesam",
+                    "ie": "Backwaren, Fr\u00fchst\u00fcckscerealien, Brotaufstriche"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "L",
+                    "be": "Schwefeldioxid, Sulfite",
+                    "ie": "Wein, weinhaltige Getr\u00e4nke, getrocknete Fr\u00fcchte, Convenience-Produkte (z.B. Bratkartoffel, Instant-Kartoffelp\u00fcree), Konserven"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 2,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_fisch_f.png",
+                "name": "Fisch",
+                "translatedfilter": "fisch"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_knoblauch_k.png",
+                "name": "Knoblauch",
+                "translatedfilter": "knoblauch"
+              }
+            ],
+            "screenid": "3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Tagessuppe 1,00 \u20ac",
+            "laufschrift": "",
+            "angebotshinweis": "Die Angebote 1 bis 4 inklusive einem Frischobst.",
+            "index": "4",
+            "matrix": "9d",
+            "beschreibung": "t",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": null
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 3,
+            "collapsed": true,
+            "labels": [],
+            "screenid": "4",
+            "els": {
+              "override": {
+                "active": true,
+                "angebot": "7.0"
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 1,
+                  "angebot": "8"
+                },
+                "linksunten": {
+                  "active": 0
+                },
+                "rechtsunten": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 4",
+            "laufschrift": "",
+            "angebotshinweis": "Die Angebote 1 bis 4 inklusive einem Frischobst.",
+            "index": "7",
+            "matrix": "9g",
+            "beschreibung": "Currysuppe mit Steckr\u00fcben, Bohnen und Paprika",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": true,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "F, Wei",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "1.00",
+            "preis_g": "4.50",
+            "id": 4,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+                "name": "vegan",
+                "translatedfilter": "vegan"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vital_m.png",
+                "name": "mensaVital",
+                "translatedfilter": "mensaVital"
+              }
+            ],
+            "screenid": "7,4",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Cafeteria Angebot",
+            "laufschrift": "",
+            "angebotshinweis": "Die Angebote 1 bis 4 inklusive einem Frischobst.",
+            "index": "8",
+            "matrix": "9h",
+            "beschreibung": "Zupfkuchen 1,60 \u20ac\nDonuts 1,30 \u20ac\nObstsalat 2,00 \u20ac\nJoghurt mit Fr\u00fcchte M\u00fcsli und Obst 2,00 \u20ac Cookie 1,30\nhausgemachte Waffeln 1,60 \u20ac\nFlaguline versch. belegt 3,00 \u20ac\nCiabatta verschieden belegt 2,50 \u20ac",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": null
+              }
+            },
+            "preis_s": {},
+            "preis_m": {},
+            "preis_g": {},
+            "id": 5,
+            "collapsed": true,
+            "labels": [],
+            "screenid": "8,4",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "6",
+        "data": "10.10.2020",
+        "freitagsmodus": {
+          "fmwert": "2",
+          "konf": [
+            {
+              "index": "1",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "2",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "3",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "4",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "5",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "6",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "7",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "8",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            }
+          ]
+        },
+        "globaleetage": {
+          "icon_eg": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_eg.png",
+          "icon_og": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_og.png",
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        },
+        "angebote": {
+          "0": {
+            "titel": "Angebot 4",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "7.1",
+            "matrix": "12g",
+            "beschreibung": "f",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": null
+              }
+            },
+            "preis_s": "1.00",
+            "preis_m": "1.00",
+            "preis_g": "1.00",
+            "id": 0,
+            "collapsed": true,
+            "labels": [],
+            "screenid": "7.1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          "-1": {
+            "variante": "7.1"
+          }
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "7",
+        "data": "11.10.2020",
+        "freitagsmodus": {
+          "fmwert": "2",
+          "konf": [
+            {
+              "index": "1",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "2",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "3",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "4",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "5",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "6",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "7",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "8",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            }
+          ]
+        },
+        "globaleetage": {
+          "icon_eg": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_eg.png",
+          "icon_og": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_og.png",
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "1",
+        "data": "12.10.2020",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "Angebot 1",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "1",
+            "matrix": "1a",
+            "beschreibung": "Gekochte Eier in Senfsauce, dazu Kartoffelp\u00fcree",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "3, C, G, J, Wei",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "J",
+                    "be": "Senf",
+                    "ie": "Ges\u00e4uerte Gem\u00fcse, Chutneys, Dressings, Wurstwaren, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": "3.10",
+            "preis_g": "3.10",
+            "id": 0,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              }
+            ],
+            "screenid": "1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 2",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "2",
+            "matrix": "1b",
+            "beschreibung": "Vegetarische Kohlroulade mit Schmorkohlsauce und Salzkartoffeln",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "C, F, Wei, Din",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Din",
+                    "be": "Dinkel-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Backwaren"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 1,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_regional.png",
+                "name": "regional",
+                "translatedfilter": "regional"
+              }
+            ],
+            "screenid": "2",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            },
+            "variante": "2.1"
+          },
+          {
+            "titel": "Angebot 2",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "2.1",
+            "matrix": "2b",
+            "beschreibung": "Kohlroulade mit Schmorkohlsauce und Salzkartoffeln",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": true,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "Wei",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 2,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+                "name": "Schwein",
+                "translatedfilter": "sau"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_regional.png",
+                "name": "regional",
+                "translatedfilter": "regional"
+              }
+            ],
+            "screenid": "2.1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "3",
+            "matrix": "1c",
+            "beschreibung": "H\u00e4hnchenbrust mit roter Currysauce, dazu Thai-Gem\u00fcse und Duftreis oder Bratnudeln",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "Wei, F, C, I, K",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "K",
+                    "be": "Sesam",
+                    "ie": "Backwaren, Fr\u00fchst\u00fcckscerealien, Brotaufstriche"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 3,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_hahn_g.png",
+                "name": "Gefl\u00fcgel",
+                "translatedfilter": "hahn"
+              }
+            ],
+            "screenid": "3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 4",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "4",
+            "matrix": "1d",
+            "beschreibung": "Limetten-Spaghetti mit Erbsen, Pilzen und Cashewkernen",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": true,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "7, Wei, Wal, Kas",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "7",
+                    "be": "gewachst",
+                    "lbz": "\u00dcberzugsmittel der Fruchtschale von Zitrusfr\u00fcchten zur Beeinflussung der Haltbarkeit."
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wal",
+                    "be": "Waln\u00fcsse und daraus hergestellte Erzeugnisse",
+                    "ie": "Studentenfutter, Snacks, Eiscreme"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Kas",
+                    "be": "Kaschun\u00fcsse und daraus hergestellte Erzeugnisse",
+                    "ie": "nur in gesch\u00e4lter und ger\u00f6steter Form als Snackangebote"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 4,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+                "name": "vegan",
+                "translatedfilter": "vegan"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vital_m.png",
+                "name": "mensaVital",
+                "translatedfilter": "mensaVital"
+              }
+            ],
+            "screenid": "4",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "2",
+        "data": "13.10.2020",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "Angebot 1",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "1",
+            "matrix": "3a",
+            "beschreibung": "Br\u00fchnudeln mit Wurzelgem\u00fcse und Sojaw\u00fcrfeln, dazu Brot",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": true,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "I, Wei, F, Rog",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Rog",
+                    "be": "Roggen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Backwaren"
+                  }
+                ]
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": "3.10",
+            "preis_g": "3.10",
+            "id": 0,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+                "name": "vegan",
+                "translatedfilter": "vegan"
+              }
+            ],
+            "screenid": "1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 2",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "2",
+            "matrix": "3b",
+            "beschreibung": "Sojastreifen in Honig-Senf-Sauce \nmit Mandel-Kartoffeln, dazu Salatmix\nund Mandarinen-Joghurt-Dressing",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "3, F, J, L, Wei, G, Man",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "J",
+                    "be": "Senf",
+                    "ie": "Ges\u00e4uerte Gem\u00fcse, Chutneys, Dressings, Wurstwaren, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "L",
+                    "be": "Schwefeldioxid, Sulfite",
+                    "ie": "Wein, weinhaltige Getr\u00e4nke, getrocknete Fr\u00fcchte, Convenience-Produkte (z.B. Bratkartoffel, Instant-Kartoffelp\u00fcree), Konserven"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Man",
+                    "be": "Mandeln und daraus hergestellte Erzeugnisse",
+                    "ie": "Marzipan, Kuchen, S\u00fc\u00dfwaren, M\u00fcslimischungen, Pesto"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 1,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              }
+            ],
+            "screenid": "2",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            },
+            "variante": "2.1"
+          },
+          {
+            "titel": "Angebot 2",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "2.1",
+            "matrix": "4b",
+            "beschreibung": "H\u00e4hnchenbruststreifen in Honig-Senf-Sauce \nmit Mandel-Kartoffeln, dazu Salatmix \nund Mandarinen-Joghurt-Dressing",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "3, J, L, Mac, G",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "J",
+                    "be": "Senf",
+                    "ie": "Ges\u00e4uerte Gem\u00fcse, Chutneys, Dressings, Wurstwaren, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "L",
+                    "be": "Schwefeldioxid, Sulfite",
+                    "ie": "Wein, weinhaltige Getr\u00e4nke, getrocknete Fr\u00fcchte, Convenience-Produkte (z.B. Bratkartoffel, Instant-Kartoffelp\u00fcree), Konserven"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Mac",
+                    "be": "Macadamian\u00fcsse und daraus hergestellte Erzeugnisse",
+                    "ie": "Desserts, Eiscreme, So\u00dfen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 2,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_hahn_g.png",
+                "name": "Gefl\u00fcgel",
+                "translatedfilter": "hahn"
+              }
+            ],
+            "screenid": "2.1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "3",
+            "matrix": "3c",
+            "beschreibung": "Wildgulasch mit Rotkohl und Kl\u00f6\u00dfe oder Sp\u00e4tzle",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": true,
+                "fisch": false,
+                "alkohol": true,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "AL, 3, L, Wei, C, Din",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "AL",
+                    "be": "mit Alkohol",
+                    "lbz": "Aroma-gebende Komponente"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "L",
+                    "be": "Schwefeldioxid, Sulfite",
+                    "ie": "Wein, weinhaltige Getr\u00e4nke, getrocknete Fr\u00fcchte, Convenience-Produkte (z.B. Bratkartoffel, Instant-Kartoffelp\u00fcree), Konserven"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Din",
+                    "be": "Dinkel-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Backwaren"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 3,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+                "name": "Schwein",
+                "translatedfilter": "sau"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_wild_h.png",
+                "name": "Wild",
+                "translatedfilter": "wild"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_alkohol_a.png",
+                "name": "Alkohol",
+                "translatedfilter": "alkohol"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_regional.png",
+                "name": "regional",
+                "translatedfilter": "regional"
+              }
+            ],
+            "screenid": "3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 4",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "4",
+            "matrix": "3d",
+            "beschreibung": "\u00c4lpler Maggerone mit Appenzeller K\u00e4se \u00fcberbacken, dazu Apfelmus und Tessiner Mischsalat",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "TL, 3, 9, G, I, Wei",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "TL",
+                    "be": "enth\u00e4lt tierisches Lab",
+                    "lbz": "thomas1"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "9",
+                    "be": "mit S\u00fc\u00dfungsmittel",
+                    "lbz": "S\u00fc\u00dfstoffe, liefern kaum Nahrungsenergie und werden deshalb u.a. in energiereduzierten Lebensmitteln eingesetzt"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 4,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              }
+            ],
+            "screenid": "4",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "3",
+        "data": "14.10.2020",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "Angebot 1",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "1",
+            "matrix": "5a",
+            "beschreibung": "Spaghetti mit Florentiner Sauce",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": true,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "KNO, Wei, G",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "KNO",
+                    "be": "mit Knoblauch",
+                    "lbz": {
+                      "@attributes": {
+                        "info": "Lebensmitteltechnologische Bedeutung des Zusatzstoffes"
+                      }
+                    }
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": "3.10",
+            "preis_g": "3.10",
+            "id": 0,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_knoblauch_k.png",
+                "name": "Knoblauch",
+                "translatedfilter": "knoblauch"
+              }
+            ],
+            "screenid": "1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 2",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "2",
+            "matrix": "5b",
+            "beschreibung": "Vegetarische Klopse mit M\u00f6hrengem\u00fcse und Salzkartoffeln oder Langkornreis",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "C, F, I, Wei",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 1,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_regional.png",
+                "name": "regional",
+                "translatedfilter": "regional"
+              }
+            ],
+            "screenid": "2",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            },
+            "variante": "2.1"
+          },
+          {
+            "titel": "Angebot 2",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "2.1",
+            "matrix": "6b",
+            "beschreibung": "K\u00f6nigsberger Klopse mit M\u00f6hrengem\u00fcse und Salzkartoffeln oder Langkornreis",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": true,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "C, G, Wei",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 2,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+                "name": "Schwein",
+                "translatedfilter": "sau"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_rind_r.png",
+                "name": "Rind",
+                "translatedfilter": "rind"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_regional.png",
+                "name": "regional",
+                "translatedfilter": "regional"
+              }
+            ],
+            "screenid": "2.1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "3",
+            "matrix": "5c",
+            "beschreibung": "Fangfrisches Fischfilet \nmit Orangen-Pfeffersauce und Fenchel-Tomaten-Gem\u00fcse, \ndazu Kartoffelgnocchi oder Bandnudeln",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": true,
+                "alkohol": true,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "3, AL, D, Wei, G, L, C",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "AL",
+                    "be": "mit Alkohol",
+                    "lbz": "Aroma-gebende Komponente"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "D",
+                    "be": "Fisch",
+                    "ie": "Paella, Bouillabaise, Worchester Sauce, asiatische W\u00fcrzpasten"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "L",
+                    "be": "Schwefeldioxid, Sulfite",
+                    "ie": "Wein, weinhaltige Getr\u00e4nke, getrocknete Fr\u00fcchte, Convenience-Produkte (z.B. Bratkartoffel, Instant-Kartoffelp\u00fcree), Konserven"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 3,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_fisch_f.png",
+                "name": "Fisch",
+                "translatedfilter": "fisch"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_alkohol_a.png",
+                "name": "Alkohol",
+                "translatedfilter": "alkohol"
+              }
+            ],
+            "screenid": "3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 4",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "4",
+            "matrix": "5d",
+            "beschreibung": "Vegane Fr\u00fchlingsrolle auf asiatischem Gem\u00fcse mit Mango-Chutney und scharfem Kokosreis",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": true,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "5, C, F, G, I, Wei, J, L",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "5",
+                    "be": "geschwefelt",
+                    "lbz": "Schwefel dient der Abt\u00f6tung von unerw\u00fcnschten Mikroorganismen"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "J",
+                    "be": "Senf",
+                    "ie": "Ges\u00e4uerte Gem\u00fcse, Chutneys, Dressings, Wurstwaren, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "L",
+                    "be": "Schwefeldioxid, Sulfite",
+                    "ie": "Wein, weinhaltige Getr\u00e4nke, getrocknete Fr\u00fcchte, Convenience-Produkte (z.B. Bratkartoffel, Instant-Kartoffelp\u00fcree), Konserven"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 4,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+                "name": "vegan",
+                "translatedfilter": "vegan"
+              }
+            ],
+            "screenid": "4",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "4",
+        "data": "15.10.2020",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "Angebot 1",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "1",
+            "matrix": "7a",
+            "beschreibung": "Hefekl\u00f6\u00dfe mit Waldbeeren oder Zimtpflaumen",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "C, G, Wei",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": "3.10",
+            "preis_g": "3.10",
+            "id": 0,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              }
+            ],
+            "screenid": "1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 2",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "2",
+            "matrix": "7b",
+            "beschreibung": "Hering nach Hausfrauen Art mit Salzkartoffeln und Salatbeilage",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": true,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "2, 9, 5, C, D, G, J, I, L",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "2",
+                    "be": "mit Konservierungsstoff",
+                    "lbz": "Erhaltung bzw. Verl\u00e4ngerung der Genusstauglichkeit des Lebensmittels."
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "9",
+                    "be": "mit S\u00fc\u00dfungsmittel",
+                    "lbz": "S\u00fc\u00dfstoffe, liefern kaum Nahrungsenergie und werden deshalb u.a. in energiereduzierten Lebensmitteln eingesetzt"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "5",
+                    "be": "geschwefelt",
+                    "lbz": "Schwefel dient der Abt\u00f6tung von unerw\u00fcnschten Mikroorganismen"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "D",
+                    "be": "Fisch",
+                    "ie": "Paella, Bouillabaise, Worchester Sauce, asiatische W\u00fcrzpasten"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "J",
+                    "be": "Senf",
+                    "ie": "Ges\u00e4uerte Gem\u00fcse, Chutneys, Dressings, Wurstwaren, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "L",
+                    "be": "Schwefeldioxid, Sulfite",
+                    "ie": "Wein, weinhaltige Getr\u00e4nke, getrocknete Fr\u00fcchte, Convenience-Produkte (z.B. Bratkartoffel, Instant-Kartoffelp\u00fcree), Konserven"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 1,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_fisch_f.png",
+                "name": "Fisch",
+                "translatedfilter": "fisch"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_regional.png",
+                "name": "regional",
+                "translatedfilter": "regional"
+              }
+            ],
+            "screenid": "2",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "3",
+            "matrix": "7c",
+            "beschreibung": "Sojasteak mit zerlassener Thymianbutter und Peperonata, dazu Kartoffelgnocchi oder Bratkartoffeln",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "2, F, G, C",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "2",
+                    "be": "mit Konservierungsstoff",
+                    "lbz": "Erhaltung bzw. Verl\u00e4ngerung der Genusstauglichkeit des Lebensmittels."
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 2,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              }
+            ],
+            "screenid": "3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            },
+            "variante": "3.1"
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "3.1",
+            "matrix": "8c",
+            "beschreibung": "Schweinesteak mit zerlassener Thymianbutter und Peperonata, dazu Kartoffelgnocchi oder Bratkartoffeln",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": true,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "Wei, C, G",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 3,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+                "name": "Schwein",
+                "translatedfilter": "sau"
+              }
+            ],
+            "screenid": "3.1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 4",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "4",
+            "matrix": "7d",
+            "beschreibung": "Gelbe Linsen mit Kokos-Curry \nund Bananen-Soja-Shake",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": true,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": true,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "KNO, F",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "KNO",
+                    "be": "mit Knoblauch",
+                    "lbz": {
+                      "@attributes": {
+                        "info": "Lebensmitteltechnologische Bedeutung des Zusatzstoffes"
+                      }
+                    }
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 4,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+                "name": "vegan",
+                "translatedfilter": "vegan"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_knoblauch_k.png",
+                "name": "Knoblauch",
+                "translatedfilter": "knoblauch"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vital_m.png",
+                "name": "mensaVital",
+                "translatedfilter": "mensaVital"
+              }
+            ],
+            "screenid": "4",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "5",
+        "data": "16.10.2020",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "Angebot 1",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "1",
+            "matrix": "9a",
+            "beschreibung": "Bunter Gem\u00fcseeintopf mit Kichererbsen, dazu Brot",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": true,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "3, I, Wei, Rog",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Rog",
+                    "be": "Roggen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Backwaren"
+                  }
+                ]
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": "3.10",
+            "preis_g": "3.10",
+            "id": 0,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+                "name": "vegan",
+                "translatedfilter": "vegan"
+              }
+            ],
+            "screenid": "1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            },
+            "variante": "1.1"
+          },
+          {
+            "titel": "Angebot 1",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "1.1",
+            "matrix": "10a",
+            "beschreibung": "Topfwurst mit buntem Sauerkraut und Salzkartoffeln",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": true,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "2, 3, 4, G, I, J, K, Wei",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "2",
+                    "be": "mit Konservierungsstoff",
+                    "lbz": "Erhaltung bzw. Verl\u00e4ngerung der Genusstauglichkeit des Lebensmittels."
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "4",
+                    "be": "mit Geschmacksverst\u00e4rker",
+                    "lbz": "zur Verst\u00e4rkung des Geschmacks der wertbestimmenden Zutaten"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "J",
+                    "be": "Senf",
+                    "ie": "Ges\u00e4uerte Gem\u00fcse, Chutneys, Dressings, Wurstwaren, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "K",
+                    "be": "Sesam",
+                    "ie": "Backwaren, Fr\u00fchst\u00fcckscerealien, Brotaufstriche"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": "3.10",
+            "preis_g": "3.10",
+            "id": 1,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+                "name": "Schwein",
+                "translatedfilter": "sau"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_regional.png",
+                "name": "regional",
+                "translatedfilter": "regional"
+              }
+            ],
+            "screenid": "1.1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 2",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "2",
+            "matrix": "9b",
+            "beschreibung": "Schweinebraten mit Rosenkohl und Serviettenkn\u00f6del oder Salzkartoffeln",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": true,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "2, G, C, Wei",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "2",
+                    "be": "mit Konservierungsstoff",
+                    "lbz": "Erhaltung bzw. Verl\u00e4ngerung der Genusstauglichkeit des Lebensmittels."
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 2,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+                "name": "Schwein",
+                "translatedfilter": "sau"
+              }
+            ],
+            "screenid": "2",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "3",
+            "matrix": "9c",
+            "beschreibung": "Seelachs in Kr\u00e4uter-Ei-H\u00fclle auf d\u00e4nischer Senfsauce mit Tricolore-Gem\u00fcse und Kartoffelgratin",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": true,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "1, 3, C, D, J, Wei, L, G",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "1",
+                    "be": "mit Farbstoff",
+                    "lbz": "Optische Aufwertung der wertbestimmenden Zutaten (z.B. h\u00f6herer Fruchtanteil in der Kaltschale)"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "D",
+                    "be": "Fisch",
+                    "ie": "Paella, Bouillabaise, Worchester Sauce, asiatische W\u00fcrzpasten"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "J",
+                    "be": "Senf",
+                    "ie": "Ges\u00e4uerte Gem\u00fcse, Chutneys, Dressings, Wurstwaren, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "L",
+                    "be": "Schwefeldioxid, Sulfite",
+                    "ie": "Wein, weinhaltige Getr\u00e4nke, getrocknete Fr\u00fcchte, Convenience-Produkte (z.B. Bratkartoffel, Instant-Kartoffelp\u00fcree), Konserven"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 3,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_fisch_f.png",
+                "name": "Fisch",
+                "translatedfilter": "fisch"
+              }
+            ],
+            "screenid": "3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 4",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "4",
+            "matrix": "9d",
+            "beschreibung": "Kartoffel-K\u00fcrbiskernr\u00f6sti \nmit Tomaten-Schnittlauchquark, dazu Blattsalatvariation",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "C, G",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 4,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vital_m.png",
+                "name": "mensaVital",
+                "translatedfilter": "mensaVital"
+              }
+            ],
+            "screenid": "4",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "6",
+        "data": "17.10.2020",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "7",
+        "data": "18.10.2020",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -52,3 +52,13 @@ def test_empty_menu():
 
     expected = _read_feed('empty_menu_output.xml')
     assert expected == actual
+
+
+def test_offers_dictionary():
+    menu = _read_menu('offers-dict.json')
+
+    actual = feed.render_menu(menu)
+
+    expected = _read_feed('offers-dict-output.xml')
+
+    assert expected == actual


### PR DESCRIPTION
Sorry to bother you again, but I finally decided to handle a variation in the API response. It only occurs randomly, maybe a couple of times a month, and then again never to be seen for an extended period of time.

Then the offers list mutates into a dictionary, whose keys are integers. Now you can represent "index" -1. This allows you store garbage. For good measure, stringify the integer keys. (\</irony>) The remainder represents valid offers  and should be parsed.