### PR TITLE
Handle empty "titel' (aka category) attribute

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,32 +18,34 @@
     "default": {
         "cachetools": {
             "hashes": [
-                "sha256:1d057645db16ca7fe1f3bd953558897603d6f0b9c51ed9d11eb4d071ec4e2aab",
-                "sha256:de5d88f87781602201cde465d3afe837546663b168e8b39df67411b0bf10cefc"
+                "sha256:1d9d5f567be80f7c07d765e21b814326d78c61eb0c3a637dffc0e5d1796cb2e2",
+                "sha256:f469e29e7aa4cff64d8de4aad95ce76de8ea1125a16c68e0d93f65c3c3dc92e9"
             ],
             "index": "pypi",
-            "version": "==4.1.0"
+            "version": "==4.2.1"
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "click": {
             "hashes": [
-                "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc",
-                "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "version": "==7.1.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==7.1.2"
         },
         "flask": {
             "hashes": [
@@ -55,24 +57,27 @@
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.9"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "itsdangerous": {
             "hashes": [
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
                 "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
-                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
+                "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
+                "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
             ],
-            "version": "==2.11.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.11.3"
         },
         "markupsafe": {
             "hashes": [
@@ -81,8 +86,12 @@
                 "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
                 "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
                 "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f",
+                "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39",
                 "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
                 "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014",
+                "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f",
                 "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
                 "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
                 "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
@@ -91,25 +100,41 @@
                 "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
                 "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
                 "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
+                "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1",
                 "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
                 "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
                 "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850",
+                "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0",
                 "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
                 "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb",
                 "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
                 "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
                 "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1",
+                "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2",
                 "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
                 "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
                 "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7",
                 "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8",
                 "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193",
                 "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b",
                 "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
                 "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5",
+                "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c",
+                "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032",
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
-                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be",
+                "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "pyopenmensa": {
@@ -121,24 +146,26 @@
         },
         "requests": {
             "hashes": [
-                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
-                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
             "index": "pypi",
-            "version": "==2.23.0"
+            "version": "==2.25.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
-            "version": "==1.25.9"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.4"
         },
         "werkzeug": {
             "hashes": [
                 "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
                 "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.0.1"
         }
     },
@@ -150,91 +177,118 @@
             ],
             "version": "==0.7.12"
         },
-        "argh": {
-            "hashes": [
-                "sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3",
-                "sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65"
-            ],
-            "version": "==0.26.2"
-        },
         "astroid": {
             "hashes": [
-                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
-                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
+                "sha256:4db03ab5fc3340cf619dbc25e42c2cc3755154ce6009469766d7143d1fc2ee4e",
+                "sha256:8a398dfce302c13f14bab13e2b14fe385d32b73f4e4853b9bdfb64598baa1975"
             ],
-            "version": "==2.3.3"
+            "markers": "python_version ~= '3.6'",
+            "version": "==2.5.6"
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
-            "version": "==19.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.3.0"
         },
         "babel": {
             "hashes": [
-                "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
-                "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
+                "sha256:9d35c22fcc79893c3ecc85ac4a56cde1ecf3f19c540bba0922308a6c06ca6fa5",
+                "sha256:da031ab54472314f210b0adcff1588ee5d1d1d0ba4dbd07b94dba82bde791e05"
             ],
-            "version": "==2.8.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.9.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.4.4"
         },
         "coverage": {
             "hashes": [
-                "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a",
-                "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355",
-                "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65",
-                "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7",
-                "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9",
-                "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1",
-                "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0",
-                "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55",
-                "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c",
-                "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6",
-                "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef",
-                "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019",
-                "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e",
-                "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0",
-                "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf",
-                "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24",
-                "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2",
-                "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c",
-                "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4",
-                "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0",
-                "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd",
-                "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04",
-                "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e",
-                "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730",
-                "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2",
-                "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768",
-                "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796",
-                "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7",
-                "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a",
-                "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489",
-                "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"
+                "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c",
+                "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6",
+                "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45",
+                "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a",
+                "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03",
+                "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529",
+                "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a",
+                "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a",
+                "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2",
+                "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6",
+                "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759",
+                "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53",
+                "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a",
+                "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4",
+                "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff",
+                "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502",
+                "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793",
+                "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb",
+                "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905",
+                "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821",
+                "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b",
+                "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81",
+                "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0",
+                "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b",
+                "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3",
+                "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184",
+                "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701",
+                "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a",
+                "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82",
+                "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638",
+                "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5",
+                "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083",
+                "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6",
+                "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90",
+                "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465",
+                "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a",
+                "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3",
+                "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e",
+                "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066",
+                "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf",
+                "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b",
+                "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae",
+                "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669",
+                "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873",
+                "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b",
+                "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6",
+                "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb",
+                "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160",
+                "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c",
+                "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079",
+                "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
+                "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
             ],
-            "version": "==5.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==5.5"
         },
         "coveralls": {
             "hashes": [
-                "sha256:41bd57b60321dfd5b56e990ab3f7ed876090691c21a9e3b005e1f6e42e6ba4b9",
-                "sha256:d213f5edd49053d03f0db316ccabfe17725f2758147afc9a37eaca9d8e8602b5"
+                "sha256:7bd173b3425733661ba3063c88f180127cc2b20e9740686f86d2622b31b41385",
+                "sha256:cbb942ae5ef3d2b55388cb5b43e93a269544911535f1e750e1c656aef019ce60"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==3.0.1"
         },
         "docopt": {
             "hashes": [
@@ -247,75 +301,88 @@
                 "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
                 "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.16"
         },
         "httpretty": {
             "hashes": [
-                "sha256:24a6fd2fe1c76e94801b74db8f52c0fb42718dc4a199a861b305b1a492b9d868"
+                "sha256:e53c927c4d3d781a0761727f1edfad64abef94e828718e12b672a678a8b3e0b5"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "version": "==1.0.5"
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.9"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "imagesize": {
             "hashes": [
                 "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
                 "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
         },
         "isort": {
             "hashes": [
-                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
-                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+                "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6",
+                "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"
             ],
-            "version": "==4.3.21"
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==5.8.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
-                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
+                "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
+                "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
             ],
-            "version": "==2.11.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.11.3"
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
-                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
-                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
-                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
-                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
-                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
-                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
-                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
-                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
-                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
-                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
-                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
-                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
-                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
-                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
-                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
-                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
-                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
-                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
-                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
-                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+                "sha256:17e0967ba374fc24141738c69736da90e94419338fd4c7c7bef01ee26b339653",
+                "sha256:1fee665d2638491f4d6e55bd483e15ef21f6c8c2095f235fef72601021e64f61",
+                "sha256:22ddd618cefe54305df49e4c069fa65715be4ad0e78e8d252a33debf00f6ede2",
+                "sha256:24a5045889cc2729033b3e604d496c2b6f588c754f7a62027ad4437a7ecc4837",
+                "sha256:410283732af311b51b837894fa2f24f2c0039aa7f220135192b38fcc42bd43d3",
+                "sha256:4732c765372bd78a2d6b2150a6e99d00a78ec963375f236979c0626b97ed8e43",
+                "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726",
+                "sha256:4f60460e9f1eb632584c9685bccea152f4ac2130e299784dbaf9fae9f49891b3",
+                "sha256:5743a5ab42ae40caa8421b320ebf3a998f89c85cdc8376d6b2e00bd12bd1b587",
+                "sha256:85fb7608121fd5621cc4377a8961d0b32ccf84a7285b4f1d21988b2eae2868e8",
+                "sha256:9698110e36e2df951c7c36b6729e96429c9c32b3331989ef19976592c5f3c77a",
+                "sha256:9d397bf41caad3f489e10774667310d73cb9c4258e9aed94b9ec734b34b495fd",
+                "sha256:b579f8acbf2bdd9ea200b1d5dea36abd93cabf56cf626ab9c744a432e15c815f",
+                "sha256:b865b01a2e7f96db0c5d12cfea590f98d8c5ba64ad222300d93ce6ff9138bcad",
+                "sha256:bf34e368e8dd976423396555078def5cfc3039ebc6fc06d1ae2c5a65eebbcde4",
+                "sha256:c6938967f8528b3668622a9ed3b31d145fab161a32f5891ea7b84f6b790be05b",
+                "sha256:d1c2676e3d840852a2de7c7d5d76407c772927addff8d742b9808fe0afccebdf",
+                "sha256:d7124f52f3bd259f510651450e18e0fd081ed82f3c08541dffc7b94b883aa981",
+                "sha256:d900d949b707778696fdf01036f58c9876a0d8bfe116e8d220cfd4b15f14e741",
+                "sha256:ebfd274dcd5133e0afae738e6d9da4323c3eb021b3e13052d8cbd0e457b1256e",
+                "sha256:ed361bb83436f117f9917d282a456f9e5009ea12fd6de8742d1a4752c3017e93",
+                "sha256:f5144c75445ae3ca2057faac03fda5a902eff196702b0a24daf1d6ce0650514b"
             ],
-            "version": "==1.4.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.6.0"
         },
         "livereload": {
             "hashes": [
-                "sha256:78d55f2c268a8823ba499305dcac64e28ddeb9a92571e12d543cd304faf5817b",
-                "sha256:89254f78d7529d7ea0a3417d224c34287ebfe266b05e67e51facaf82c27f0f66"
+                "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"
             ],
-            "version": "==2.6.1"
+            "version": "==2.6.3"
         },
         "markupsafe": {
             "hashes": [
@@ -324,8 +391,12 @@
                 "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
                 "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
                 "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f",
+                "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39",
                 "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
                 "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014",
+                "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f",
                 "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
                 "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
                 "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
@@ -334,25 +405,41 @@
                 "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
                 "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
                 "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
+                "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1",
                 "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
                 "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
                 "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850",
+                "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0",
                 "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
                 "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb",
                 "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
                 "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
                 "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1",
+                "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2",
                 "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
                 "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
                 "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7",
                 "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8",
                 "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193",
                 "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b",
                 "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
                 "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5",
+                "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c",
+                "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032",
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
-                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be",
+                "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "mccabe": {
@@ -362,174 +449,146 @@
             ],
             "version": "==0.6.1"
         },
-        "more-itertools": {
-            "hashes": [
-                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
-                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
-            ],
-            "version": "==8.2.0"
-        },
         "packaging": {
             "hashes": [
-                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
-                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
             ],
-            "version": "==20.3"
-        },
-        "pathtools": {
-            "hashes": [
-                "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"
-            ],
-            "version": "==0.1.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.9"
         },
         "pluggy": {
             "hashes": [
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
-        },
-        "port-for": {
-            "hashes": [
-                "sha256:b16a84bb29c2954db44c29be38b17c659c9c27e33918dec16b90d375cc596f1c"
-            ],
-            "version": "==0.3.1"
         },
         "py": {
             "hashes": [
-                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
-                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
-            "version": "==1.8.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
+                "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
             ],
             "index": "pypi",
-            "version": "==2.5.0"
+            "version": "==2.7.0"
         },
         "pydocstyle": {
             "hashes": [
-                "sha256:da7831660b7355307b32778c4a0dbfb137d89254ef31a2b2978f50fc0b4d7586",
-                "sha256:f4f5d210610c2d153fae39093d44224c17429e2ad7da12a8b419aba5c2f614b5"
+                "sha256:164befb520d851dbcf0e029681b91f4f599c62c5cd8933fd54b1bfbd50e89e1f",
+                "sha256:d4449cf16d7e6709f63192146706933c7a334af7c0f083904799ccb851c50f6d"
             ],
             "index": "pypi",
-            "version": "==5.0.2"
+            "version": "==6.0.0"
         },
         "pygments": {
             "hashes": [
-                "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
-                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
+                "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94",
+                "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"
             ],
-            "version": "==2.6.1"
+            "markers": "python_version >= '3.5'",
+            "version": "==2.8.1"
         },
         "pylint": {
             "hashes": [
-                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
-                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
+                "sha256:4236b7284853b779a8add49aca287a5899245894995c5591d2b5839a32482330",
+                "sha256:ad1bff19c46bfc6d2aeba4de5f76570d253df4915d2043ba61dc6a96233c4bd6"
             ],
             "index": "pypi",
-            "version": "==2.4.4"
+            "version": "==2.8.1"
         },
         "pyparsing": {
             "hashes": [
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634",
+                "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"
             ],
             "index": "pypi",
-            "version": "==5.4.1"
+            "version": "==6.2.3"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
-                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+                "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7",
+                "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==2.11.1"
         },
         "pytz": {
             "hashes": [
-                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
-                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
+                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
             ],
-            "version": "==2019.3"
-        },
-        "pyyaml": {
-            "hashes": [
-                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
-                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
-                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
-                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
-                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
-                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
-                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
-                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
-                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
-                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
-                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
-            ],
-            "version": "==5.3.1"
+            "version": "==2021.1"
         },
         "requests": {
             "hashes": [
-                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
-                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
             "index": "pypi",
-            "version": "==2.23.0"
+            "version": "==2.25.1"
         },
         "six": {
             "hashes": [
-                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
-                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.14.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
-                "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
+                "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2",
+                "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"
             ],
-            "version": "==2.0.0"
+            "version": "==2.1.0"
         },
         "sphinx": {
             "hashes": [
-                "sha256:3145d87d0962366d4c5264c39094eae3f5788d01d4b1a12294051bfe4271d91b",
-                "sha256:d7c6e72c6aa229caf96af82f60a0d286a1521d42496c226fe37f5a75dcfe2941"
+                "sha256:19010b7b9fa0dc7756a6e105b2aacd3a80f798af3c25c273be64d7beeb482cb1",
+                "sha256:2320d4e994a191f4b4be27da514e46b3d6b420f2ff895d064f52415d342461e8"
             ],
             "index": "pypi",
-            "version": "==3.0.2"
+            "version": "==3.5.4"
         },
         "sphinx-autobuild": {
             "hashes": [
-                "sha256:66388f81884666e3821edbe05dd53a0cfb68093873d17320d0610de8db28c74e",
-                "sha256:e60aea0789cab02fa32ee63c7acae5ef41c06f1434d9fd0a74250a61f5994692"
+                "sha256:8fe8cbfdb75db04475232f05187c776f46f6e9e04cacf1e49ce81bdac649ccac",
+                "sha256:de1ca3b66e271d2b5b5140c35034c89e47f263f2cd5db302c9217065f7443f05"
             ],
             "index": "pypi",
-            "version": "==0.7.1"
+            "version": "==2021.3.14"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4",
-                "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"
+                "sha256:32bd3b5d13dc8186d7a42fc816a23d32e83a4827d7d9882948e7b837c232da5a",
+                "sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f"
             ],
             "index": "pypi",
-            "version": "==0.4.3"
+            "version": "==0.5.2"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
                 "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
                 "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-devhelp": {
@@ -537,6 +596,7 @@
                 "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
                 "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-htmlhelp": {
@@ -544,6 +604,7 @@
                 "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
                 "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-jsmath": {
@@ -551,6 +612,7 @@
                 "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
                 "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "sphinxcontrib-qthelp": {
@@ -558,6 +620,7 @@
                 "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
                 "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-serializinghtml": {
@@ -565,47 +628,77 @@
                 "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc",
                 "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.1.4"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
         },
         "tornado": {
             "hashes": [
-                "sha256:0fe2d45ba43b00a41cd73f8be321a44936dc1aba233dee979f17a042b83eb6dc",
-                "sha256:22aed82c2ea340c3771e3babc5ef220272f6fd06b5108a53b4976d0d722bcd52",
-                "sha256:2c027eb2a393d964b22b5c154d1a23a5f8727db6fda837118a776b29e2b8ebc6",
-                "sha256:5217e601700f24e966ddab689f90b7ea4bd91ff3357c3600fa1045e26d68e55d",
-                "sha256:5618f72e947533832cbc3dec54e1dffc1747a5cb17d1fd91577ed14fa0dc081b",
-                "sha256:5f6a07e62e799be5d2330e68d808c8ac41d4a259b9cea61da4101b83cb5dc673",
-                "sha256:c58d56003daf1b616336781b26d184023ea4af13ae143d9dda65e31e534940b9",
-                "sha256:c952975c8ba74f546ae6de2e226ab3cc3cc11ae47baf607459a6728585bb542a",
-                "sha256:c98232a3ac391f5faea6821b53db8db461157baa788f5d6222a193e9456e1740"
+                "sha256:0a00ff4561e2929a2c37ce706cb8233b7907e0cdc22eab98888aca5dd3775feb",
+                "sha256:0d321a39c36e5f2c4ff12b4ed58d41390460f798422c4504e09eb5678e09998c",
+                "sha256:1e8225a1070cd8eec59a996c43229fe8f95689cb16e552d130b9793cb570a288",
+                "sha256:20241b3cb4f425e971cb0a8e4ffc9b0a861530ae3c52f2b0434e6c1b57e9fd95",
+                "sha256:25ad220258349a12ae87ede08a7b04aca51237721f63b1808d39bdb4b2164558",
+                "sha256:33892118b165401f291070100d6d09359ca74addda679b60390b09f8ef325ffe",
+                "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791",
+                "sha256:3447475585bae2e77ecb832fc0300c3695516a47d46cefa0528181a34c5b9d3d",
+                "sha256:34ca2dac9e4d7afb0bed4677512e36a52f09caa6fded70b4e3e1c89dbd92c326",
+                "sha256:3e63498f680547ed24d2c71e6497f24bca791aca2fe116dbc2bd0ac7f191691b",
+                "sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4",
+                "sha256:6196a5c39286cc37c024cd78834fb9345e464525d8991c21e908cc046d1cc02c",
+                "sha256:61b32d06ae8a036a6607805e6720ef00a3c98207038444ba7fd3d169cd998910",
+                "sha256:6286efab1ed6e74b7028327365cf7346b1d777d63ab30e21a0f4d5b275fc17d5",
+                "sha256:65d98939f1a2e74b58839f8c4dab3b6b3c1ce84972ae712be02845e65391ac7c",
+                "sha256:66324e4e1beede9ac79e60f88de548da58b1f8ab4b2f1354d8375774f997e6c0",
+                "sha256:6c77c9937962577a6a76917845d06af6ab9197702a42e1346d8ae2e76b5e3675",
+                "sha256:70dec29e8ac485dbf57481baee40781c63e381bebea080991893cd297742b8fd",
+                "sha256:7250a3fa399f08ec9cb3f7b1b987955d17e044f1ade821b32e5f435130250d7f",
+                "sha256:748290bf9112b581c525e6e6d3820621ff020ed95af6f17fedef416b27ed564c",
+                "sha256:7da13da6f985aab7f6f28debab00c67ff9cbacd588e8477034c0652ac141feea",
+                "sha256:8f959b26f2634a091bb42241c3ed8d3cedb506e7c27b8dd5c7b9f745318ddbb6",
+                "sha256:9de9e5188a782be6b1ce866e8a51bc76a0fbaa0e16613823fc38e4fc2556ad05",
+                "sha256:a48900ecea1cbb71b8c71c620dee15b62f85f7c14189bdeee54966fbd9a0c5bd",
+                "sha256:b87936fd2c317b6ee08a5741ea06b9d11a6074ef4cc42e031bc6403f82a32575",
+                "sha256:c77da1263aa361938476f04c4b6c8916001b90b2c2fdd92d8d535e1af48fba5a",
+                "sha256:cb5ec8eead331e3bb4ce8066cf06d2dfef1bfb1b2a73082dfe8a161301b76e37",
+                "sha256:cc0ee35043162abbf717b7df924597ade8e5395e7b66d18270116f8745ceb795",
+                "sha256:d14d30e7f46a0476efb0deb5b61343b1526f73ebb5ed84f23dc794bdb88f9d9f",
+                "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32",
+                "sha256:d3d20ea5782ba63ed13bc2b8c291a053c8d807a8fa927d941bd718468f7b950c",
+                "sha256:d3f7594930c423fd9f5d1a76bee85a2c36fd8b4b16921cae7e965f22575e9c01",
+                "sha256:dcef026f608f678c118779cd6591c8af6e9b4155c44e0d1bc0c87c036fb8c8c4",
+                "sha256:e0791ac58d91ac58f694d8d2957884df8e4e2f6687cdf367ef7eb7497f79eaa2",
+                "sha256:e385b637ac3acaae8022e7e47dfa7b83d3620e432e3ecb9a3f7f58f150e50921",
+                "sha256:e519d64089b0876c7b467274468709dadf11e41d65f63bba207e04217f47c085",
+                "sha256:e7229e60ac41a1202444497ddde70a48d33909e484f96eb0da9baf8dc68541df",
+                "sha256:ed3ad863b1b40cd1d4bd21e7498329ccaece75db5a5bf58cd3c9f130843e7102",
+                "sha256:f0ba29bafd8e7e22920567ce0d232c26d4d47c8b5cf4ed7b562b5db39fa199c5",
+                "sha256:fa2ba70284fa42c2a5ecb35e322e68823288a4251f9ba9cc77be04ae15eada68",
+                "sha256:fba85b6cd9c39be262fcd23865652920832b61583de2a2ca907dbd8e8a8c81e5"
             ],
-            "version": "==6.0.4"
+            "markers": "python_version >= '3.5'",
+            "version": "==6.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
-            "version": "==1.25.9"
-        },
-        "watchdog": {
-            "hashes": [
-                "sha256:c560efb643faed5ef28784b2245cf8874f939569717a4a12826a173ac644456b"
-            ],
-            "version": "==0.10.2"
-        },
-        "wcwidth": {
-            "hashes": [
-                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
-                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
-            ],
-            "version": "==0.1.9"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.4"
         },
         "wrapt": {
             "hashes": [
-                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
             ],
-            "version": "==1.11.2"
+            "version": "==1.12.1"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenMensa Parser STW Potsdam
 
-[![Build Status](https://travis-ci.org/f4lco/om-parser-stw-potsdam-v2.svg?branch=master)](https://travis-ci.org/f4lco/om-parser-stw-potsdam-v2)
+[![Build Status](https://travis-ci.com/f4lco/om-parser-stw-potsdam-v2.svg?branch=master)](https://travis-ci.com/f4lco/om-parser-stw-potsdam-v2)
 [![Coverage Status](https://coveralls.io/repos/github/f4lco/om-parser-stw-potsdam-v2/badge.svg?branch=master)](https://coveralls.io/github/f4lco/om-parser-stw-potsdam-v2?branch=master)
 [![Read the Docs](https://readthedocs.org/projects/om-parser-stw-potsdam-v2/badge/?version=latest&style=flat)](https://om-parser-stw-potsdam-v2.readthedocs.io/en/latest/)
 

--- a/stw_potsdam/feed.py
+++ b/stw_potsdam/feed.py
@@ -42,11 +42,18 @@ def _prices(offer):
 def _process_day(builder, day):
     for offer in _offers(day):
         builder.addMeal(date=day['data'],
-                        category=offer['titel'],
+                        category=_category(offer),
                         name=offer['beschreibung'],
                         notes=_notes(offer),
                         prices=_prices(offer),
                         roles=None)
+
+
+def _category(offer):
+    # 'Angebot' is just a placeholder. We cannot tell if 'Angebot' or 'Info' is
+    # more appropriate because offers lacking the 'titel' attribute are real
+    # meals or informational texts.
+    return offer['titel'] or 'Angebot'
 
 
 def _offers(day):

--- a/tests/resources/missing-category-output.xml
+++ b/tests/resources/missing-category-output.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openmensa version="2.1" xmlns="http://openmensa.org/open-mensa-v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://openmensa.org/open-mensa-v2 http://openmensa.org/open-mensa-v2.xsd">
+  <canteen>
+    <day date="2021-01-27">
+      <category name="Angebot 3">
+        <meal>
+          <name>a</name>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+        <meal>
+          <name>Fangfrisches Lachsfilet auf Blattspinat, dazu Grillkartoffeln</name>
+          <note>Fisch</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Angebot">
+        <meal>
+          <name>Linsensuppe mit Wiener Würstchen, dazu Brot</name>
+          <note>Rind</note>
+          <note>Schwein</note>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 1">
+        <meal>
+          <name>Vegane Frühlingsrolle mit Kokos- Currysauce, dazu Wokgemüse und Langkornreis</name>
+          <note>Knoblauch</note>
+          <note>Vegan</note>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Info">
+        <meal>
+          <name>Die Mensen Am Neuen Palais und Golm bleiben geöffnet.
+Sie können Ihr Mittagessen vor Ort verzehren oder to go mitnehmen.
+Der Foodhopper in der Kaiser-Friedrich-Straße bietet ausschließlich Mittagessen to go an.</name>
+          <price role="employee">3.90</price>
+          <price role="other">0.00</price>
+          <price role="student">0.00</price>
+        </meal>
+      </category>
+    </day>
+    <day date="2021-01-28">
+      <category name="Angebot 3">
+        <meal>
+          <name>Veganes Sojasteak mit geschmorten Zwiebeln, dazu Bratkartoffeln und Salat</name>
+          <note>Vegan</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+        <meal>
+          <name>Schweinenackensteak mit geschmorten Zwiebeln, dazu Bratkartoffeln und Salat</name>
+          <note>Schwein</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 1">
+        <meal>
+          <name>Nudeln mit Bolognesesauce</name>
+          <note>Knoblauch</note>
+          <note>Rind</note>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+      </category>
+      <category name="Info">
+        <meal>
+          <name>Die Mensen Am Neuen Palais und Golm bleiben geöffnet.
+Sie können Ihr Mittagessen vor Ort verzehren oder to go mitnehmen.
+Der Foodhopper in der Kaiser-Friedrich-Straße bietet ausschließlich Mittagessen to go an.</name>
+          <price role="employee">3.90</price>
+          <price role="other">0.00</price>
+          <price role="student">0.00</price>
+        </meal>
+      </category>
+    </day>
+    <day date="2021-01-29">
+      <category name="Angebot">
+        <meal>
+          <name>Die Mensen Am Neuen Palais und Golm bleiben geöffnet.
+Sie können Ihr Mittagessen vor Ort verzehren oder to go mitnehmen.
+Der Foodhopper in der Kaiser-Friedrich-Straße bietet ausschließlich Mittagessen to go an.</name>
+          <price role="employee">3.90</price>
+          <price role="other">3.90</price>
+          <price role="student">2.10</price>
+        </meal>
+        <meal>
+          <name>Hefeklöße mit heißen Früchten</name>
+          <note>Vegetarisch</note>
+        </meal>
+        <meal>
+          <name>Germknödel mit Vanillesauce</name>
+          <note>Alkohol</note>
+          <note>Vegetarisch</note>
+        </meal>
+      </category>
+      <category name="Angebot 3">
+        <meal>
+          <name>Vegane Gemüsefrikdelle mit Ajvar-Dip, dazu Bulgur und Salat</name>
+          <note>Vegan</note>
+          <price role="employee">4.50</price>
+          <price role="other">4.50</price>
+          <price role="student">2.60</price>
+        </meal>
+      </category>
+      <category name="Angebot 1">
+        <meal>
+          <name>Currywurst mit hausgemachter Sauce, dazu Pommes frites und Salat</name>
+          <note>Schwein</note>
+        </meal>
+      </category>
+    </day>
+    <day date="2021-02-01">
+      <category name="Info">
+        <meal>
+          <name>Liebe Gäste! Den Speiseplan der laufenden Woche finden Sie immer montags hier .</name>
+          <price role="employee">3.10</price>
+          <price role="other">3.10</price>
+          <price role="student">1.60</price>
+        </meal>
+      </category>
+    </day>
+  </canteen>
+</openmensa>

--- a/tests/resources/missing-category.json
+++ b/tests/resources/missing-category.json
@@ -1,0 +1,2244 @@
+{
+  "globalLaufschrift": "",
+  "wochentage": [
+    {
+      "datum": {
+        "wochentag": "3",
+        "data": "27.01.2021",
+        "freitagsmodus": {
+          "fmwert": "2",
+          "konf": [
+            {
+              "index": "1",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "2",
+              "vonscreen": "1,4",
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "3",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "4",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "5",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": "2",
+                "linksunten": {},
+                "rechtsoben": "5",
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "6",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "7",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "8",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            }
+          ]
+        },
+        "globaleetage": {
+          "icon_eg": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_eg.png",
+          "icon_og": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_og.png",
+          "screenConfs": {
+            "screenog": [
+              "1",
+              "4",
+              "7",
+              "8"
+            ]
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_vegan_w.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_vegan_w.png"
+          ],
+          "vital": [],
+          "schwein": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_schwein_s.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_schwein_s.png"
+          ],
+          "fisch": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_fisch_f.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_fisch_f.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_fisch_f.png"
+          ],
+          "rind": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_rind_r.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_rind_r.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_rind_r.png"
+          ],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_knoblauch_k.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_knoblauch_k.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_knoblauch_k.png"
+          ],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "Angebot 3",
+            "laufschrift": "",
+            "angebotshinweis": "Alle Angebote inklusive einem Frischobst.",
+            "index": "3",
+            "matrix": "5c",
+            "beschreibung": "a",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": null
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 0,
+            "collapsed": true,
+            "labels": [],
+            "screenid": "3",
+            "tmpvariante": "3.1",
+            "els": {
+              "override": {
+                "active": true,
+                "angebot": "6.0"
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 1,
+                  "angebot": "5"
+                },
+                "linksunten": {
+                  "active": 1,
+                  "angebot": "3.1"
+                },
+                "rechtsunten": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            },
+            "variante": "3.1"
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": null,
+            "angebotshinweis": "Alle Angebote inklusive einem Frischobst.",
+            "index": "3.1",
+            "matrix": "6c",
+            "beschreibung": "Fangfrisches Lachsfilet auf Blattspinat, dazu Grillkartoffeln",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": true,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "D",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "D",
+                    "be": "Fisch",
+                    "ie": "Paella, Bouillabaise, Worchester Sauce, asiatische W\u00fcrzpasten"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 1,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_fisch_f.png",
+                "name": "Fisch",
+                "translatedfilter": "fisch"
+              }
+            ],
+            "screenid": "3.1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 1,
+                  "angebot": "5.1"
+                },
+                "linksunten": {
+                  "active": 0
+                },
+                "rechtsunten": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "",
+            "laufschrift": "",
+            "angebotshinweis": "Alle Angebote inklusive einem Frischobst.",
+            "index": "5",
+            "matrix": "5e",
+            "beschreibung": "Linsensuppe mit Wiener W\u00fcrstchen, dazu Brot",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": true,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "2, 3, 4, 8, I, Wei, Rog",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "2",
+                    "be": "mit Konservierungsstoff",
+                    "lbz": "Erhaltung bzw. Verl\u00e4ngerung der Genusstauglichkeit des Lebensmittels."
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "4",
+                    "be": "mit Geschmacksverst\u00e4rker",
+                    "lbz": "zur Verst\u00e4rkung des Geschmacks der wertbestimmenden Zutaten"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "8",
+                    "be": "mit Phosphat",
+                    "lbz": "Bestandteil des Erbgutes aller Lebewesen und ist in Lebensmitteln tierischen Ursprungs enthalten. Phosphatverbindungen werden u.a. als S\u00e4uerungsmittel in Cola, Wurstwaren eingesetzt"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Rog",
+                    "be": "Roggen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Backwaren"
+                  }
+                ]
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": {},
+            "preis_g": "3.10",
+            "id": 2,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+                "name": "Schwein",
+                "translatedfilter": "sau"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_rind_r.png",
+                "name": "Rind",
+                "translatedfilter": "rind"
+              }
+            ],
+            "screenid": "5,3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 1",
+            "laufschrift": "",
+            "angebotshinweis": "Alle Angebote inklusive einem Frischobst.",
+            "index": "6",
+            "matrix": "5f",
+            "beschreibung": "Vegane Fr\u00fchlingsrolle mit Kokos- Currysauce, dazu Wokgem\u00fcse und Langkornreis",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": true,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": true,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "KNO, 2, C, F, G, I, Wei",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "KNO",
+                    "be": "mit Knoblauch",
+                    "lbz": {
+                      "@attributes": {
+                        "info": "Lebensmitteltechnologische Bedeutung des Zusatzstoffes"
+                      }
+                    }
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "2",
+                    "be": "mit Konservierungsstoff",
+                    "lbz": "Erhaltung bzw. Verl\u00e4ngerung der Genusstauglichkeit des Lebensmittels."
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": {},
+            "preis_g": "4.50",
+            "id": 3,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+                "name": "vegan",
+                "translatedfilter": "vegan"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_knoblauch_k.png",
+                "name": "Knoblauch",
+                "translatedfilter": "knoblauch"
+              }
+            ],
+            "screenid": "6,3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Info",
+            "laufschrift": "",
+            "angebotshinweis": "Alle Angebote inklusive einem Frischobst.",
+            "index": "7",
+            "matrix": "5g",
+            "beschreibung": "Die Mensen Am Neuen Palais und Golm bleiben ge\u00f6ffnet.\nSie k\u00f6nnen Ihr Mittagessen vor Ort verzehren oder to go mitnehmen.\nDer Foodhopper in der Kaiser-Friedrich-Stra\u00dfe bietet ausschlie\u00dflich Mittagessen to go an.",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": null
+              }
+            },
+            "preis_s": "0.00",
+            "preis_m": "3.90",
+            "preis_g": "0.00",
+            "id": 4,
+            "collapsed": true,
+            "labels": [],
+            "screenid": "7",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "4",
+        "data": "28.01.2021",
+        "freitagsmodus": {
+          "fmwert": "2",
+          "konf": [
+            {
+              "index": "1",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "2",
+              "vonscreen": "1,4",
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "3",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "4",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "5",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": "2",
+                "linksunten": {},
+                "rechtsoben": "5",
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "6",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "7",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "8",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            }
+          ]
+        },
+        "globaleetage": {
+          "icon_eg": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_eg.png",
+          "icon_og": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_og.png",
+          "screenConfs": {
+            "screenog": [
+              "1",
+              "4",
+              "7",
+              "8"
+            ]
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_vegan_w.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_vegan_w.png"
+          ],
+          "vital": [],
+          "schwein": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_schwein_s.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_schwein_s.png"
+          ],
+          "fisch": [],
+          "rind": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_rind_r.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_rind_r.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_rind_r.png"
+          ],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_knoblauch_k.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_knoblauch_k.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_knoblauch_k.png"
+          ],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "Angebot 3",
+            "laufschrift": "",
+            "angebotshinweis": null,
+            "index": "3",
+            "matrix": "7c",
+            "beschreibung": "Veganes Sojasteak mit geschmorten Zwiebeln, dazu Bratkartoffeln und Salat",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": true,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "2, F",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "2",
+                    "be": "mit Konservierungsstoff",
+                    "lbz": "Erhaltung bzw. Verl\u00e4ngerung der Genusstauglichkeit des Lebensmittels."
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 0,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+                "name": "vegan",
+                "translatedfilter": "vegan"
+              }
+            ],
+            "screenid": "3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            },
+            "variante": "3.1"
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "3.1",
+            "matrix": "8c",
+            "beschreibung": "Schweinenackensteak mit geschmorten Zwiebeln, dazu Bratkartoffeln und Salat",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": true,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": null
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 1,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+                "name": "Schwein",
+                "translatedfilter": "sau"
+              }
+            ],
+            "screenid": "3.1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 1",
+            "laufschrift": "",
+            "angebotshinweis": null,
+            "index": "6",
+            "matrix": "7f",
+            "beschreibung": "Nudeln mit Bolognesesauce",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": true,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "KNO, Wei, I",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "KNO",
+                    "be": "mit Knoblauch",
+                    "lbz": {
+                      "@attributes": {
+                        "info": "Lebensmitteltechnologische Bedeutung des Zusatzstoffes"
+                      }
+                    }
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  }
+                ]
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": {},
+            "preis_g": "3.10",
+            "id": 2,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_rind_r.png",
+                "name": "Rind",
+                "translatedfilter": "rind"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_knoblauch_k.png",
+                "name": "Knoblauch",
+                "translatedfilter": "knoblauch"
+              }
+            ],
+            "screenid": "6",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Info",
+            "laufschrift": "",
+            "angebotshinweis": null,
+            "index": "7",
+            "matrix": "7g",
+            "beschreibung": "Die Mensen Am Neuen Palais und Golm bleiben ge\u00f6ffnet.\nSie k\u00f6nnen Ihr Mittagessen vor Ort verzehren oder to go mitnehmen.\nDer Foodhopper in der Kaiser-Friedrich-Stra\u00dfe bietet ausschlie\u00dflich Mittagessen to go an.",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": null
+              }
+            },
+            "preis_s": "0.00",
+            "preis_m": "3.90",
+            "preis_g": "0.00",
+            "id": 3,
+            "collapsed": true,
+            "labels": [],
+            "screenid": "7",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "5",
+        "data": "29.01.2021",
+        "freitagsmodus": {
+          "fmwert": "2",
+          "konf": [
+            {
+              "index": "1",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "2",
+              "vonscreen": "1,4",
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "3",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "4",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "5",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": "2",
+                "linksunten": {},
+                "rechtsoben": "5",
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "6",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "7",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "8",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            }
+          ]
+        },
+        "globaleetage": {
+          "icon_eg": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_eg.png",
+          "icon_og": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_og.png",
+          "screenConfs": {
+            "screenog": [
+              "1",
+              "4",
+              "7",
+              "8"
+            ]
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_vegetarisch_v.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_vegetarisch_v.png"
+          ],
+          "vegan": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_vegan_w.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_vegan_w.png"
+          ],
+          "vital": [],
+          "schwein": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_schwein_s.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_schwein_s.png"
+          ],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_alkohol_a.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_alkohol_a.png",
+            "https:\/\/xml.stw-potsdam.de\/images\/icons\/kl_alkohol_a.png"
+          ],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "",
+            "laufschrift": "",
+            "angebotshinweis": null,
+            "index": "2",
+            "matrix": "9b",
+            "beschreibung": "Die Mensen Am Neuen Palais und Golm bleiben ge\u00f6ffnet.\nSie k\u00f6nnen Ihr Mittagessen vor Ort verzehren oder to go mitnehmen.\nDer Foodhopper in der Kaiser-Friedrich-Stra\u00dfe bietet ausschlie\u00dflich Mittagessen to go an.",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": null
+              }
+            },
+            "preis_s": "2.10",
+            "preis_m": "3.90",
+            "preis_g": "3.90",
+            "id": 0,
+            "collapsed": true,
+            "labels": [],
+            "screenid": "2",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 3",
+            "laufschrift": "",
+            "angebotshinweis": null,
+            "index": "3",
+            "matrix": "9c",
+            "beschreibung": "Vegane Gem\u00fcsefrikdelle mit Ajvar-Dip, dazu Bulgur und Salat",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": true,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "3, 5, I, Wei, L",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "5",
+                    "be": "geschwefelt",
+                    "lbz": "Schwefel dient der Abt\u00f6tung von unerw\u00fcnschten Mikroorganismen"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "I",
+                    "be": "Sellerie",
+                    "ie": "Gew\u00fcrzmischungen, Salatsaucenbasis, Instant-Br\u00fchen, Fleischwaren, Ketchup, Bratlinge"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "L",
+                    "be": "Schwefeldioxid, Sulfite",
+                    "ie": "Wein, weinhaltige Getr\u00e4nke, getrocknete Fr\u00fcchte, Convenience-Produkte (z.B. Bratkartoffel, Instant-Kartoffelp\u00fcree), Konserven"
+                  }
+                ]
+              }
+            },
+            "preis_s": "2.60",
+            "preis_m": "4.50",
+            "preis_g": "4.50",
+            "id": 1,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegan_w.png",
+                "name": "vegan",
+                "translatedfilter": "vegan"
+              }
+            ],
+            "screenid": "3",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "",
+            "laufschrift": "",
+            "angebotshinweis": null,
+            "index": "5",
+            "matrix": "9e",
+            "beschreibung": "Hefekl\u00f6\u00dfe mit hei\u00dfen Fr\u00fcchten",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "C, G, Wei",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": {},
+            "preis_m": {},
+            "preis_g": {},
+            "id": 2,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              }
+            ],
+            "screenid": "5",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            },
+            "variante": "5.1"
+          },
+          {
+            "titel": "",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "5.1",
+            "matrix": "10e",
+            "beschreibung": "Germkn\u00f6del mit Vanillesauce",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": true,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": true,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": false
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "AL, C, G, Wei",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "AL",
+                    "be": "mit Alkohol",
+                    "lbz": "Aroma-gebende Komponente"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "C",
+                    "be": "Eier",
+                    "ie": "Mayonnaisen, Remouladen, Teigwaren (Tortellini, Sp\u00e4tzle, Schupfnudeln), Gnocchi, Backwaren, Panaden, gekl\u00e4rte und gebundene Suppen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "Wei",
+                    "be": "Weizen-Glutenhaltiges Getreide oder Hybridst\u00e4mme sowie daraus hergestellte Erzeugnisse",
+                    "ie": "Couscous, Bulgur, Saitan, Puddings, Grie\u00dfspeisen, Backwaren, als Bindemittel in Dessertzubereitungen"
+                  }
+                ]
+              }
+            },
+            "preis_s": {},
+            "preis_m": {},
+            "preis_g": {},
+            "id": 3,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_vegetarisch_v.png",
+                "name": "vegetarisch",
+                "translatedfilter": "vegetarisch"
+              },
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_alkohol_a.png",
+                "name": "Alkohol",
+                "translatedfilter": "alkohol"
+              }
+            ],
+            "screenid": "5.1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          },
+          {
+            "titel": "Angebot 1",
+            "laufschrift": "",
+            "angebotshinweis": null,
+            "index": "6",
+            "matrix": "9f",
+            "beschreibung": "Currywurst mit hausgemachter Sauce, dazu Pommes frites und Salat",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": true,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "8, 21, 3, 4, 9, F, G, J",
+              "additives": {
+                "additive": [
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "8",
+                    "be": "mit Phosphat",
+                    "lbz": "Bestandteil des Erbgutes aller Lebewesen und ist in Lebensmitteln tierischen Ursprungs enthalten. Phosphatverbindungen werden u.a. als S\u00e4uerungsmittel in Cola, Wurstwaren eingesetzt"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "21",
+                    "be": "mit Koffein",
+                    "lbz": "Aroma-gebende Komponente"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "3",
+                    "be": "mit Antioxidationsmittel",
+                    "lbz": "wie (1) und (2)"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "4",
+                    "be": "mit Geschmacksverst\u00e4rker",
+                    "lbz": "zur Verst\u00e4rkung des Geschmacks der wertbestimmenden Zutaten"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Zusatzstoff"
+                    },
+                    "ke": "9",
+                    "be": "mit S\u00fc\u00dfungsmittel",
+                    "lbz": "S\u00fc\u00dfstoffe, liefern kaum Nahrungsenergie und werden deshalb u.a. in energiereduzierten Lebensmitteln eingesetzt"
+                  }
+                ]
+              },
+              "allergens": {
+                "allergen": [
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "F",
+                    "be": "Soja",
+                    "ie": "Milch- und Sahneersatz auf Sojabasis, Tofu, Sojasauce, Zusatzstoff in S\u00fcsswaren v.a. in Schokolade, Wurst- und Fleischwaren"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "G",
+                    "be": "Milch",
+                    "ie": "Backwaren, vegetarische Bratlinge, Wurstwaren, Dressings und W\u00fcrzsaucen"
+                  },
+                  {
+                    "@attributes": {
+                      "info": "Allergen"
+                    },
+                    "ke": "J",
+                    "be": "Senf",
+                    "ie": "Ges\u00e4uerte Gem\u00fcse, Chutneys, Dressings, Wurstwaren, Bratlinge"
+                  }
+                ]
+              }
+            },
+            "preis_s": {},
+            "preis_m": {},
+            "preis_g": {},
+            "id": 4,
+            "collapsed": true,
+            "labels": [
+              {
+                "icon": "https:\/\/xml.stw-potsdam.de\/images\/icons\/su_schwein_s.png",
+                "name": "Schwein",
+                "translatedfilter": "sau"
+              }
+            ],
+            "screenid": "6",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "6",
+        "data": "30.01.2021",
+        "freitagsmodus": {
+          "fmwert": "2",
+          "konf": [
+            {
+              "index": "1",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "2",
+              "vonscreen": "1,4",
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "3",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "4",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "5",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": "2",
+                "linksunten": {},
+                "rechtsoben": "5",
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "6",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "7",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "8",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            }
+          ]
+        },
+        "globaleetage": {
+          "icon_eg": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_eg.png",
+          "icon_og": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_og.png",
+          "screenConfs": {
+            "screenog": [
+              "1",
+              "4",
+              "7",
+              "8"
+            ]
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "7",
+        "data": "31.01.2021",
+        "freitagsmodus": {
+          "fmwert": "2",
+          "konf": [
+            {
+              "index": "1",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "2",
+              "vonscreen": "1,4",
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "3",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "4",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "5",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": "2",
+                "linksunten": {},
+                "rechtsoben": "5",
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "6",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "7",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            },
+            {
+              "index": "8",
+              "vonscreen": {},
+              "angebotemanuell": {
+                "linksoben": {},
+                "linksunten": {},
+                "rechtsoben": {},
+                "rechtsunten": {}
+              }
+            }
+          ]
+        },
+        "globaleetage": {
+          "icon_eg": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_eg.png",
+          "icon_og": "https:\/\/xml.stw-potsdam.de\/images\/icons\/gr_og.png",
+          "screenConfs": {
+            "screenog": [
+              "1",
+              "4",
+              "7",
+              "8"
+            ]
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "1",
+        "data": "01.02.2021",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        },
+        "angebote": [
+          {
+            "titel": "Info",
+            "laufschrift": null,
+            "angebotshinweis": null,
+            "index": "1",
+            "matrix": "1a",
+            "beschreibung": "Liebe G\u00e4ste! Den Speiseplan der laufenden Woche finden Sie immer montags hier .",
+            "filter": {
+              "zutaten": {
+                "hahn": true,
+                "rind": true,
+                "sau": false,
+                "fisch": false,
+                "alkohol": false,
+                "knoblauch": false,
+                "regional": true,
+                "lamm": false,
+                "vegetarisch": false,
+                "vegan": false,
+                "vital": false,
+                "flexitarisch": true
+              },
+              "date": {
+                "index": 0
+              }
+            },
+            "additivesAllergens": {
+              "string": "",
+              "additives": {
+                "additive": null
+              },
+              "allergens": {
+                "allergen": null
+              }
+            },
+            "preis_s": "1.60",
+            "preis_m": "3.10",
+            "preis_g": "3.10",
+            "id": 0,
+            "collapsed": true,
+            "labels": [],
+            "screenid": "1",
+            "els": {
+              "override": {
+                "active": false
+              },
+              "splitscreen": {
+                "rechtsoben": {
+                  "active": 0
+                }
+              },
+              "speciallabel": {
+                "foodtruck": {
+                  "active": null,
+                  "icon": null
+                },
+                "ostern": {
+                  "active": null,
+                  "icon": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "2",
+        "data": "02.02.2021",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "3",
+        "data": "03.02.2021",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "4",
+        "data": "04.02.2021",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "5",
+        "data": "05.02.2021",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "6",
+        "data": "06.02.2021",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    },
+    {
+      "datum": {
+        "wochentag": "7",
+        "data": "07.02.2021",
+        "freitagsmodus": {
+          "fmwert": null,
+          "konf": []
+        },
+        "globaleetage": {
+          "icon_eg": null,
+          "icon_og": null,
+          "screenConfs": {
+            "screenog": []
+          }
+        },
+        "tageslabel": {
+          "vegetarisch": [],
+          "vegan": [],
+          "vital": [],
+          "schwein": [],
+          "fisch": [],
+          "rind": [],
+          "gefluegel": [],
+          "alkohol": [],
+          "lamm": [],
+          "knoblauch": [],
+          "regional": []
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -62,3 +62,13 @@ def test_offers_dictionary():
     expected = _read_feed('offers-dict-output.xml')
 
     assert expected == actual
+
+
+def test_missing_category():
+    menu = _read_menu('missing-category.json')
+
+    actual = feed.render_menu(menu)
+
+    expected = _read_feed('missing-category-output.xml')
+
+    assert expected == actual


### PR DESCRIPTION
I was recently observing crashes with empty 'titel' attributes from the API response. The OpenMensa feed insists that the string must not be empty.